### PR TITLE
Remove Password on Login

### DIFF
--- a/src/templates/views/login.pug
+++ b/src/templates/views/login.pug
@@ -7,7 +7,7 @@ block content
 
     .window-central.elevation-1
             h2 Login
-            p Access to this connectBox administration interface. Default password is 'connectbox'
+            p Access to this connectBox administration interface.
             form#loginForm(action='/')
                 div
                     label.m-3(for='password') Password:


### PR DESCRIPTION
Removed the default message with the old password on the login screen:

![Screen Shot 2022-08-19 at 1 54 46 PM](https://user-images.githubusercontent.com/540521/185705969-4a014331-b6f9-46f3-8a02-a4a5768b301c.png)

